### PR TITLE
fix: tooltip show single app chart

### DIFF
--- a/R/panels.R
+++ b/R/panels.R
@@ -76,7 +76,7 @@ panel <- function(head = NULL, body = NULL, footer = NULL,
           can_collapse
       ),
       div(class="panel-body", id = id_body,
-          div(class="panel-content",
+          div(class="panel-content",icon(""),
               body
           )
       ),


### PR DESCRIPTION
Related with https://github.com/datasketch/app-simple-charts-orgs issue #4:
no funciona la informacion adicional que se le agrega a un widget

input_info:
icon: info-circle
text: tooltip_info()

revisar parmesan y si funciona en parmesan porque no funciona en la app